### PR TITLE
add shlex to support multi-item fields

### DIFF
--- a/emtable/metadata.py
+++ b/emtable/metadata.py
@@ -199,16 +199,19 @@ class _Reader(_ColumnsList):
                 print(i)
             raise e
 
-    def getRow(self, shlex=False):
+    def getRow(self, shlex=None):
         """ Get the next Row, it is None when not more rows. """
         result = self._row
+
+        if shlex is None:
+            shlex = self._shlex
 
         if self._singleRow:
             self._row = None
         elif result is not None:
             line = self._file.readline().strip()
             line = None if line.startswith("data_") else line
-            self._row = self.__rowFromValues(_split(line, shlex=self._shlex)) if line else None
+            self._row = self.__rowFromValues(_split(line, shlex=shlex)) if line else None
 
         return result
 
@@ -244,7 +247,7 @@ class _Reader(_ColumnsList):
         return list(iter(self))
 
     def __iter__(self):
-        row = self.getRow(shlex=self._shlex)
+        row = self.getRow()
 
         while row is not None:
             yield row

--- a/emtable/metadata.py
+++ b/emtable/metadata.py
@@ -583,13 +583,8 @@ def _getFormatStr(v):
 
 def _split(string, shlex=False):
     if shlex:
-        try:
-            import shlex
-        except ImportError:
-            raise ImportError('Use of the shlex option requires the '
-                              'installation of the shlex package.')
-        else:
-            return shlex.split(string)
+        import shlex
+        return shlex.split(string)
     else:
         return string.split()
 


### PR DESCRIPTION
emtable cannot handle fields with multiple entries enclosed in quotes such as the nma deformation coefficients from HEMNMA:
```
# XMIPP_STAR_1 * 
# 
data_noname
loop_
 _anglePsi
 _angleRot
 _angleTilt
 _cost
 _enabled
 _image
 _itemId
 _nmaDisplacements
 _shiftX
 _shiftY
 -180.009437   -96.153255   243.098777 8.055914e-04                    1 000021@Runs/000088_ProtImportParticles/extra/img.stk                   21 '    -2.733360    -2.468260    -0.090721 '    -4.306965    -0.040850 
    0.225648   206.555090     9.899219 7.811945e-04                    1 000002@Runs/000088_ProtImportParticles/extra/img.stk                    2 '   -41.891100   -41.568300     0.332499 '    -4.426523    -1.497812 
   -0.046492    44.646616   140.304778 7.839426e-04                    1 000008@Runs/000088_ProtImportParticles/extra/img.stk                    8 '   -32.927700   -32.664600    -0.040520 '    -4.787815    -1.810996 
```

The first quotation mark is already followed by a space and that marks the end of the field for emtable and the first item ends up in the next field:
```
In [1]: import emtable

In [2]: table = emtable.metadata.Table()

In [3]: table.readStar("TestHEMNMA_1/Runs/000162_FlexProtAlignmentNMA/extra/images.xmd")

In [4]: vals = table.getColumnValues("nmaDisplacements")

In [5]: vals[:10]
Out[5]: ["'", "'", "'", "'", "'", "'", "'", "'", "'", "'"]

In [6]: next_vals = table.getColumnValues("shiftX")

In [7]: next_vals[:10]
Out[7]: 
[-2.73336,
 -41.8911,
 -32.9277,
 -9.28306,
 -1.53702,
 -83.4403,
 -18.0662,
 -43.0212,
 -54.1365,
 -38.3291]
```

By using shlex, we can split the data to take into account this storage method and recover the right values:
```
In [8]: table.readStar(
   ...:     "TestHEMNMA_1/Runs/000162_FlexProtAlignmentNMA/extra/images.xmd", shlex=True
   ...: )

In [9]: vals = table.getColumnValues("nmaDisplacements")

In [10]: vals[:10]
Out[10]: 
['    -2.733360    -2.468260    -0.090721 ',
 '   -41.891100   -41.568300     0.332499 ',
 '   -32.927700   -32.664600    -0.040520 ',
 '    -9.283060   -11.415600    -0.460911 ',
 '    -1.537020    -0.685835     0.171922 ',
 '   -83.440300   -81.905200     0.549659 ',
 '   -18.066200   -18.385300    -0.002269 ',
 '   -43.021200   -42.989300    -0.529935 ',
 '   -54.136500   -53.140500    -0.374566 ',
 '   -38.329100   -37.508300     0.130949 ']

In [11]: next_vals = table.getColumnValues("shiftX")

In [12]: next_vals[:10]
Out[12]: 
[-4.306965,
 -4.426523,
 -4.787815,
 -3.019745,
 -2.256845,
 -2.858181,
 -1.259468,
 -0.973478,
 -2.526699,
 -4.273127]
```

By default, shlex is set to False, keeping the default behaviour unchanged. 